### PR TITLE
Feature/add planner edit screen

### DIFF
--- a/src/components/Common/ProposalButton.js
+++ b/src/components/Common/ProposalButton.js
@@ -17,7 +17,9 @@ const PlannerButton = styled.TouchableOpacity`
   flex: 1;
   padding: 12px 135px;
   background: ${props =>
-    props.selectedPlanner == '' && props.isClicked ? '#F3F3F3' : '#e2f955'};
+    Number.isInteger(props.selected.id) && props.isClicked
+      ? '#e2f955'
+      : '#F3F3F3'};
   align-content: center;
   justify-content: center;
   border-radius: 5px;
@@ -31,13 +33,7 @@ const PlannerText = styled.Text`
   color: #000000;
 `;
 
-const ProposalButton = ({
-  state,
-  isClicked,
-  setIsClicked,
-  selectedPlanner,
-  setSelectedPlanner,
-}) => {
+const ProposalButton = ({state, isClicked, setIsClicked, selected}) => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const planners = useSelector(state => state.planners.planners);
@@ -45,23 +41,22 @@ const ProposalButton = ({
   return (
     <BottomConatiner>
       <PlannerButton
-        selectedPlanner={selectedPlanner}
+        selected={selected}
         isClicked={isClicked}
         onPress={() => {
-          if (selectedPlanner == '') {
-            setIsClicked(!isClicked);
-          } else {
+          console.log(selected);
+          console.log(Number.isInteger(selected.id));
+          if (selected.hasOwnProperty('id')) {
             const category =
               state.hasOwnProperty('foodSet') ||
               state.hasOwnProperty('foodSingle')
                 ? 'food'
                 : 'rec';
-            const planner = planners.find(
-              planner => planner.title === selectedPlanner,
-            );
 
-            dispatch(addItems(planner.id, state.items, category));
-            navigation.navigate('Planner', {id: planner.id});
+            dispatch(addItems(selected.id, state.items, category));
+            navigation.navigate('Planner', {id: selected.id});
+          } else {
+            setIsClicked(!isClicked);
           }
         }}>
         <PlannerText>기획서</PlannerText>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, Text, Image, Pressable} from 'react-native';
 import styled from 'styled-components';
+import {useSelector} from 'react-redux';
 import {useNavigation} from '@react-navigation/native';
 
 const HeaderContainer = styled.View`
@@ -69,11 +70,17 @@ export const HeaderTitle = ({title}) => {
 };
 
 export const HeaderRight = () => {
+  const planners = useSelector(state => state.planners.planners);
   const navigation = useNavigation();
+
   return (
     <HeaderProgram
       onPress={() => {
-        navigation.navigate('Planner', {id: 0});
+        if (planners.length > 0) {
+          navigation.navigate('Planner', {id: 0});
+        } else {
+          navigation.navigate('PlanEditor');
+        }
       }}>
       <HeaderProgramImage
         source={require('../../../assets/projectfile_w.png')}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, Text, Image, Pressable} from 'react-native';
 import styled from 'styled-components';
 import {useSelector} from 'react-redux';
-import {useNavigation} from '@react-navigation/native';
+import {useNavigation, useRoute} from '@react-navigation/native';
 
 const HeaderContainer = styled.View`
   flex-direction: row;
@@ -62,7 +62,7 @@ export const HeaderLeft = ({canGoBack}) => {
 };
 
 export const HeaderTitle = ({title}) => {
-  if (title == '홈') {
+  if (title === '홈') {
     return <HeaderTitleImage source={require('../../../assets/mount.png')} />;
   } else {
     return <HeaderText>{title}</HeaderText>;
@@ -72,14 +72,15 @@ export const HeaderTitle = ({title}) => {
 export const HeaderRight = () => {
   const planners = useSelector(state => state.planners.planners);
   const navigation = useNavigation();
+  const route = useRoute();
 
   return (
     <HeaderProgram
       onPress={() => {
-        if (planners.length > 0) {
-          navigation.navigate('Planner', {id: 0});
-        } else {
+        if (route.name === 'Planner' || planners.length === 0) {
           navigation.navigate('PlanEditor');
+        } else {
+          navigation.navigate('Planner', {id: 0});
         }
       }}>
       <HeaderProgramImage

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -73,7 +73,7 @@ export const HeaderRight = () => {
   return (
     <HeaderProgram
       onPress={() => {
-        navigation.navigate('Planner');
+        navigation.navigate('Planner', {id: 0});
       }}>
       <HeaderProgramImage
         source={require('../../../assets/projectfile_w.png')}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -27,12 +27,7 @@ const AddPlannerText = styled.Text`
   color: #8b8b8b;
 `;
 
-const Modal = ({
-  isClicked,
-  setIsClicked,
-  selectedPlanner,
-  setSelectedPlanner,
-}) => {
+const Modal = ({selected, setSelected}) => {
   const planners = useSelector(state => state.planners.planners);
   const dispatch = useDispatch();
 
@@ -59,8 +54,8 @@ const Modal = ({
             <Planner
               key={planner.title + index}
               planner={planner}
-              selectedPlanner={selectedPlanner}
-              setSelectedPlanner={setSelectedPlanner}
+              selected={selected}
+              setSelected={setSelected}
             />
           );
         })}

--- a/src/components/Plan/TotalPrice.js
+++ b/src/components/Plan/TotalPrice.js
@@ -80,7 +80,6 @@ const TotalPriceText = styled.Text`
 `;
 
 const TotalPrice = ({isPressedArr, memberCnt, setMemberCnt}) => {
-  console.log(isPressedArr[0].count);
   let price = 0;
   for (let i = 0; i < isPressedArr.length; i++) {
     price = parseInt(
@@ -88,7 +87,6 @@ const TotalPrice = ({isPressedArr, memberCnt, setMemberCnt}) => {
       10,
     );
   }
-  console.log(price);
   let total = memberCnt * price;
   return (
     <TotalContainer>

--- a/src/components/Plan/TotalPrice.js
+++ b/src/components/Plan/TotalPrice.js
@@ -79,18 +79,21 @@ const TotalPriceText = styled.Text`
   text-align: right;
 `;
 
-const TotalPrice = ({isPressedArr, memberCnt, setMemberCnt}) => {
-  let price = 0;
-  for (let i = 0; i < isPressedArr.length; i++) {
-    price = parseInt(
-      (price + isPressedArr[i].count * isPressedArr[i].price) / memberCnt,
-      10,
-    );
-  }
-  let total = memberCnt * price;
+const TotalPrice = ({state}) => {
+  console.log('🚀 ~ file: TotalPrice.js ~ line 83 ~ TotalPrice ~ state', state);
+  // state = {id, items: {rec, food}, tittle}
+
+  // let price = 0;
+  // for (let i = 0; i < isPressedArr.length; i++) {
+  //   price = parseInt(
+  //     (price + isPressedArr[i].count * isPressedArr[i].price) / memberCnt,
+  //     10,
+  //   );
+  // }
+  // let total = memberCnt * price;
   return (
     <TotalContainer>
-      <StyledTitle>총 예상금액</StyledTitle>
+      {/* <StyledTitle>총 예상금액</StyledTitle>
       <SmallContainer>
         <PriceBox>
           <PriceBoxTitle>1인 기준</PriceBoxTitle>
@@ -104,7 +107,7 @@ const TotalPrice = ({isPressedArr, memberCnt, setMemberCnt}) => {
           <TotalPriceTitle>총 금액</TotalPriceTitle>
           <TotalPriceText>{total} 원</TotalPriceText>
         </TotalPriceBox>
-      </SmallContainer>
+      </SmallContainer> */}
     </TotalContainer>
   );
 };

--- a/src/components/Planner.js
+++ b/src/components/Planner.js
@@ -24,20 +24,19 @@ const PlanerTitle = styled.Text`
   line-height: 24px;
 `;
 
-const PlannerTitle = ({planner, selectedPlanner, setSelectedPlanner}) => {
-  const [isSelected, setIsSelected] = useState(
-    planner?.title == selectedPlanner,
-  );
+const PlannerTitle = ({planner, selected, setSelected}) => {
+  const [isSelected, setIsSelected] = useState(planner?.id === selected.id);
 
   useEffect(() => {
-    setIsSelected(planner.title == selectedPlanner);
-  }, [selectedPlanner]);
+    setIsSelected(planner?.id === selected.id);
+  }, [selected]);
+
   return (
     <PlannerContainer>
       <PlannerButton
         isSelected={isSelected}
         onPress={() => {
-          setSelectedPlanner(planner?.title);
+          setSelected({id: planner?.id});
         }}>
         <PlanerTitle isSelected={isSelected}>{planner?.title}</PlanerTitle>
       </PlannerButton>

--- a/src/navigation/Main.js
+++ b/src/navigation/Main.js
@@ -3,6 +3,7 @@ import {createStackNavigator} from '@react-navigation/stack';
 import Tabs from './Tab';
 import Details from './Details';
 import Plan from '../screens/Main/Plan';
+import PlanEditor from '../screens/Main/PlanEditor';
 import {Header} from '../components/Header/Header';
 
 const MainNavigator = createStackNavigator();
@@ -19,10 +20,8 @@ export default () => (
       component={Details}
       options={{headerShown: false}}
     />
-    <MainNavigator.Screen
-      name="Planner"
-      component={Plan}
-      options={{
+    <MainNavigator.Group
+      screenOptions={{
         header: ({navigation, route, options, back}) => (
           <Header
             navigation={navigation}
@@ -32,7 +31,9 @@ export default () => (
           />
         ),
         tabBarLabel: '기획서',
-      }}
-    />
+      }}>
+      <MainNavigator.Screen name="Planner" component={Plan} />
+      <MainNavigator.Screen name="PlanEditor" component={PlanEditor} />
+    </MainNavigator.Group>
   </MainNavigator.Navigator>
 );

--- a/src/screens/Main/ChangeCount/FoodSetChangeCount/FoodSetChangeCountPresenter.js
+++ b/src/screens/Main/ChangeCount/FoodSetChangeCount/FoodSetChangeCountPresenter.js
@@ -122,6 +122,7 @@ const TotalPriceContainer = styled.View`
 const FoodSetChangeCountPresenter = ({state, setState}) => {
   const [isClicked, setIsClicked] = useState(false);
   const [selectedPlanner, setSelectedPlanner] = useState('');
+  const [selected, setSelected] = useState({});
 
   return (
     <PageWrap>
@@ -203,15 +204,10 @@ const FoodSetChangeCountPresenter = ({state, setState}) => {
             isClicked={isClicked}
             onPress={() => {
               setIsClicked(false);
-              setSelectedPlanner('');
+              setSelected({});
             }}
           />
-          <Modal
-            isClicked={isClicked}
-            setIsClicked={setIsClicked}
-            selectedPlanner={selectedPlanner}
-            setSelectedPlanner={setSelectedPlanner}
-          />
+          <Modal selected={selected} setSelected={setSelected} />
         </>
       ) : (
         <></>
@@ -220,20 +216,10 @@ const FoodSetChangeCountPresenter = ({state, setState}) => {
         state={state}
         isClicked={isClicked}
         setIsClicked={setIsClicked}
-        selectedPlanner={selectedPlanner}
-        setSelectedPlanner={setSelectedPlanner}
+        selected={selected}
       />
     </PageWrap>
   );
 };
-
-// isClicked == true && selectedPlanner == ''
-// => 기획서 버튼 비활성화
-
-// isClicked == true && selectedPlanner == '최강산디MT'
-// => 기획서 버튼 활성화 + 버튼 클릭 시 planer로 navigate
-
-// isClicked == false
-// => do nothing
 
 export default FoodSetChangeCountPresenter;

--- a/src/screens/Main/Detail/RecreationSet/RecreationSetPresenter.js
+++ b/src/screens/Main/Detail/RecreationSet/RecreationSetPresenter.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import TitleContainer from '../../../../components/Common/SetTitle';
 import Counter from '../../../../components/Rec/Counter';
 import Item from '../../../../components/Common/Item';
+import FocusAwareStatusBar from '../../../../components/StatusBar';
 import TotalPrice from '../../../../components/Common/TotalPrice';
 import Caution from '../../../../components/Common/Caution';
 
@@ -133,6 +134,8 @@ const TotalPriceContainer = styled.View`
 const RecreationSetPresenter = ({state, setState}) => {
   return (
     <PageWrap style={{flex: 1}}>
+      <FocusAwareStatusBar barStyle="light-content" backgroundColor="#000000" />
+
       <ScrollContainer>
         <TitleContainer
           img={state?.recSet?.img}

--- a/src/screens/Main/Plan/PlanPresenter.js
+++ b/src/screens/Main/Plan/PlanPresenter.js
@@ -167,7 +167,7 @@ export default ({state, setState}) => {
         <Divider></Divider>
         <PlanItemsContainer category={'음식'} items={state?.planner.items} />
         <TotalPriceContainer>
-          <TotalPrice state={state?.planner} />
+          {/* <TotalPrice state={state?.planner} /> */}
         </TotalPriceContainer>
         <Divider></Divider>
         <CautionContainer>

--- a/src/screens/Main/Plan/PlanPresenter.js
+++ b/src/screens/Main/Plan/PlanPresenter.js
@@ -167,7 +167,7 @@ export default ({state, setState}) => {
         <Divider></Divider>
         <PlanItemsContainer category={'음식'} items={state?.planner.items} />
         <TotalPriceContainer>
-          {/* <TotalPrice state={state?.planner} /> */}
+          <TotalPrice state={state?.planner} />
         </TotalPriceContainer>
         <Divider></Divider>
         <CautionContainer>

--- a/src/screens/Main/PlanEditor/PlanEditorContainer.js
+++ b/src/screens/Main/PlanEditor/PlanEditorContainer.js
@@ -1,0 +1,8 @@
+import React, {useState, useEffect} from 'react';
+import {useSelector} from 'react-redux';
+import {useNavigation} from '@react-navigation/native';
+import PlanEditorPresenter from './PlanEditorPresenter';
+
+export default ({navigation, route}) => {
+  return <PlanEditorPresenter />;
+};

--- a/src/screens/Main/PlanEditor/PlanEditorPresenter.js
+++ b/src/screens/Main/PlanEditor/PlanEditorPresenter.js
@@ -1,9 +1,10 @@
 import React, {useState, useEffect} from 'react';
 import {Dimensions, ScrollView, Pressable} from 'react-native';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import styled from 'styled-components';
 import {useNavigation} from '@react-navigation/native';
 import FocusAwareStatusBar from '../../../components/StatusBar';
+import {createPlanner, deletePlanner} from '../../../store/actions/planners';
 import {
   Planedit_newprojectfileSvg,
   MoreSvg,
@@ -36,6 +37,8 @@ const BtnText = styled.Text`
 
 const PlanersContainer = styled.View``;
 
+const PlannerContainer = styled.View``;
+
 const Planner = styled.Pressable`
   flex-direction: row;
   justify-content: space-between;
@@ -59,14 +62,22 @@ const Divider = styled.View`
 
 export default ({state, setState}) => {
   const [isEditing, setIsEditing] = useState(false);
+
+  const planners = useSelector(state => state.planners.planners);
   const navigation = useNavigation();
   const dispatch = useDispatch();
 
-  const navigateToPlan = id => {};
+  const navigateToPlan = id => {
+    navigation.navigate('Planner', {id});
+  };
 
-  const addNewPlan = () => {};
+  const addNewPlan = () => {
+    dispatch(createPlanner('새 기획서'));
+  };
 
-  const deletePlan = () => {};
+  const deletePlan = id => {
+    dispatch(deletePlanner(id));
+  };
 
   return (
     <PlanEditContainer>
@@ -83,22 +94,31 @@ export default ({state, setState}) => {
         </PlanBtn>
       </BtnContainer>
       <PlanersContainer>
-        <Planner>
-          <PlannerName>새 기획서</PlannerName>
-          {isEditing ? (
-            <Pressable onPress={deletePlan}>
-              <Planedit_minus_Svg width={24} height={24} />
-            </Pressable>
-          ) : (
-            <Pressable
-              onPress={() => {
-                navigateToPlan(0);
-              }}>
-              <MoreSvg width={24} height={24} />
-            </Pressable>
-          )}
-        </Planner>
-        <Divider />
+        {planners.map(p => {
+          return (
+            <PlannerContainer key={p.id}>
+              <Planner>
+                <PlannerName>{p.title}</PlannerName>
+                {isEditing ? (
+                  <Pressable
+                    onPress={() => {
+                      deletePlan(p.id);
+                    }}>
+                    <Planedit_minus_Svg width={24} height={24} />
+                  </Pressable>
+                ) : (
+                  <Pressable
+                    onPress={() => {
+                      navigateToPlan(p.id);
+                    }}>
+                    <MoreSvg width={24} height={24} />
+                  </Pressable>
+                )}
+              </Planner>
+              <Divider />
+            </PlannerContainer>
+          );
+        })}
       </PlanersContainer>
     </PlanEditContainer>
   );

--- a/src/screens/Main/PlanEditor/PlanEditorPresenter.js
+++ b/src/screens/Main/PlanEditor/PlanEditorPresenter.js
@@ -1,0 +1,13 @@
+import React, {useState, useEffect} from 'react';
+import {Dimensions} from 'react-native';
+import {useDispatch} from 'react-redux';
+import styled from 'styled-components';
+import {useNavigation} from '@react-navigation/native';
+import FocusAwareStatusBar from '../../../components/StatusBar';
+
+export default ({state, setState}) => {
+  const navigation = useNavigation();
+  const dispatch = useDispatch();
+
+  return <></>;
+};

--- a/src/screens/Main/PlanEditor/PlanEditorPresenter.js
+++ b/src/screens/Main/PlanEditor/PlanEditorPresenter.js
@@ -1,13 +1,105 @@
 import React, {useState, useEffect} from 'react';
-import {Dimensions} from 'react-native';
+import {Dimensions, ScrollView, Pressable} from 'react-native';
 import {useDispatch} from 'react-redux';
 import styled from 'styled-components';
 import {useNavigation} from '@react-navigation/native';
 import FocusAwareStatusBar from '../../../components/StatusBar';
+import {
+  Planedit_newprojectfileSvg,
+  MoreSvg,
+  Planedit_minus_Svg,
+} from '../../../components/assets';
+
+const PlanEditContainer = styled.ScrollView`
+  background-color: #ffffff;
+`;
+
+const BtnContainer = styled.View`
+  padding: 12px 21px 32px 14px;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const PlanBtn = styled.Pressable``;
+
+const BtnText = styled.Text`
+  padding: 6px 15px 7px 14px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+  background: ${props => (props.isEditing ? '#E2F955' : '#f3f3f3')};
+  color: #000000;
+  font-size: 14px;
+  font-family: 'NotoSansKR-Regular';
+  line-height: 20px;
+`;
+
+const PlanersContainer = styled.View``;
+
+const Planner = styled.Pressable`
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 23px 33px 22px 21px;
+`;
+
+const PlannerName = styled.Text`
+  color: #000000;
+  font-size: 16px;
+  font-family: 'NotoSansKR-Regular';
+  line-height: 24px;
+`;
+
+const PlannerBtn = styled.Pressable``;
+
+const Divider = styled.View`
+  /* border: 1.3px solid #F3F3F3; */
+  border-bottom-width: 1.3px;
+  border-bottom-color: #f3f3f3;
+`;
 
 export default ({state, setState}) => {
+  const [isEditing, setIsEditing] = useState(false);
   const navigation = useNavigation();
   const dispatch = useDispatch();
 
-  return <></>;
+  const navigateToPlan = id => {};
+
+  const addNewPlan = () => {};
+
+  const deletePlan = () => {};
+
+  return (
+    <PlanEditContainer>
+      <FocusAwareStatusBar barStyle="dark-content" backgroundColor="#ffffff" />
+      <BtnContainer>
+        <PlanBtn onPress={addNewPlan}>
+          <Planedit_newprojectfileSvg />
+        </PlanBtn>
+        <PlanBtn
+          onPress={() => {
+            setIsEditing(!isEditing);
+          }}>
+          <BtnText isEditing={isEditing}>{isEditing ? '저장' : '편집'}</BtnText>
+        </PlanBtn>
+      </BtnContainer>
+      <PlanersContainer>
+        <Planner>
+          <PlannerName>새 기획서</PlannerName>
+          {isEditing ? (
+            <Pressable onPress={deletePlan}>
+              <Planedit_minus_Svg width={24} height={24} />
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={() => {
+                navigateToPlan(0);
+              }}>
+              <MoreSvg width={24} height={24} />
+            </Pressable>
+          )}
+        </Planner>
+        <Divider />
+      </PlanersContainer>
+    </PlanEditContainer>
+  );
 };

--- a/src/screens/Main/PlanEditor/index.js
+++ b/src/screens/Main/PlanEditor/index.js
@@ -1,0 +1,3 @@
+import PlanEditorContainer from './PlanEditorContainer';
+
+export default PlanEditorContainer;

--- a/src/store/actions/planners.js
+++ b/src/store/actions/planners.js
@@ -1,6 +1,7 @@
 export const CREATE_PLANNER = 'CREATE_PLANNER';
 export const ADD_ITEM = 'ADD_ITEM';
 export const ADD_ITEMS = 'ADD_ITEMS';
+export const DELETE_PLANNER = 'DELETE_PLANNER';
 export const MODIFY_TITLE = 'MODIFY_TITLE';
 export const UPDATE_PLANNER = 'UPDATE_PLANNER';
 
@@ -16,6 +17,9 @@ export const addItems = (id, items, category) => {
   return {type: ADD_ITEMS, id, items, category};
 };
 
+export const deletePlanner = id => {
+  return {type: DELETE_PLANNER, id};
+};
 export const modifyPlannerTitle = (planner, title) => {
   return {type: MODIFY_TITLE, planner, title};
 };

--- a/src/store/reducers/planners.js
+++ b/src/store/reducers/planners.js
@@ -25,7 +25,7 @@ export default (state = initialState, action) => {
       const newItem = action.item;
 
       const addedPlanners = state.planners.map(planner => {
-        if (planner.id == id) {
+        if (planner.id === id) {
           return {
             ...planner,
             items: {
@@ -48,7 +48,7 @@ export default (state = initialState, action) => {
       const category = action.category;
       const newItems = action.items;
       const addedPlanners = state.planners.map(planner => {
-        if (planner.id == id) {
+        if (planner.id === id) {
           return {
             ...planner,
             items: {
@@ -67,9 +67,9 @@ export default (state = initialState, action) => {
       };
     }
     case 'DELETE_PLANNER': {
-      const planner = action.planner;
+      const id = action.id;
       const deletedPlanners = state.planners.filter((value, index, arr) => {
-        return value.id != planner.id;
+        return value.id !== id;
       });
       return {
         ...state,
@@ -94,7 +94,7 @@ export default (state = initialState, action) => {
     case 'UPDATE_PLANNER': {
       const planner = action.planner;
       const modifiedPlanners = state.planners.map(item => {
-        if (item.id == planner.id) {
+        if (item.id === planner.id) {
           return planner;
         } else {
           return item;


### PR DESCRIPTION
## 개요
- 기획서 편집 화면 추가했습니다.
- changeCount 화면에서  Planner로 이동 시 title이 아닌 id로 planner를 찾도록 변경했습니다.

## 작업사항
### components
- src/components/Common/ProposalButton.js 
- src/components/Header/Header.js 
- src/components/Modal.js 
- src/components/Plan/TotalPrice.js 
- src/components/Planner.js 
### navigation
- src/navigation/Main.js 
### screens
- src/screens/Main/ChangeCount/FoodSetChangeCount/FoodSetChangeCountPresenter.js 
- src/screens/Main/Plan/PlanPresenter.js 
- src/screens/Main/PlanEditor/PlanEditorContainer.js 
- src/screens/Main/PlanEditor/PlanEditorPresenter.js 
- src/screens/Main/PlanEditor/index.js 
### redux
- src/store/actions/planners.js 
- src/store/reducers/planners.js 
