### PR TITLE
Feature/add plan storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@ant-design/react-native": "^4.2.0",
+        "@react-native-async-storage/async-storage": "^1.15.17",
         "@react-native-google-signin/google-signin": "^7.0.4",
         "@react-native-seoul/kakao-login": "^3.4.3",
         "@react-navigation/bottom-tabs": "^6.0.7",
@@ -2768,6 +2769,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.15.17",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz",
+      "integrity": "sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0"
       }
     },
     "node_modules/@react-native-community/cameraroll": {
@@ -8881,6 +8893,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -10933,6 +10953,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -18394,6 +18425,14 @@
         "fastq": "^1.6.0"
       }
     },
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.17",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz",
+      "integrity": "sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==",
+      "requires": {
+        "merge-options": "^3.0.4"
+      }
+    },
     "@react-native-community/cameraroll": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.1.2.tgz",
@@ -23083,6 +23122,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -24698,6 +24742,14 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
+      }
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
       }
     },
     "merge-stream": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@ant-design/react-native": "^4.2.0",
+    "@react-native-async-storage/async-storage": "^1.15.17",
     "@react-native-google-signin/google-signin": "^7.0.4",
     "@react-native-seoul/kakao-login": "^3.4.3",
     "@react-navigation/bottom-tabs": "^6.0.7",

--- a/src/api/storage.js
+++ b/src/api/storage.js
@@ -1,0 +1,21 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const PLANNER_KEY = '@planners';
+
+export const storeData = async (key, value) => {
+  try {
+    const jsonValue = JSON.stringify(value);
+    await AsyncStorage.setItem(key, jsonValue);
+  } catch (e) {
+    // saving error
+  }
+};
+
+export const getData = async key => {
+  try {
+    const jsonValue = await AsyncStorage.getItem(key);
+    return jsonValue != null ? JSON.parse(jsonValue) : null;
+  } catch (e) {
+    // error reading value
+  }
+};

--- a/src/components/Gate.js
+++ b/src/components/Gate.js
@@ -2,17 +2,24 @@ import React, {useState, useEffect} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import Auth from '../navigation/Auth';
 import Main from '../navigation/Main';
-import {useSelector} from 'react-redux';
+import {useSelector, useDispatch} from 'react-redux';
+import {PLANNER_KEY, getData} from '../api/storage';
+import {addPlanners} from '../store/actions/planners';
+
 import {AsyncStorage} from 'react-native';
 
 export default () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const userData = useSelector(state => state.users);
+  const dispatch = useDispatch();
   // 앱 처음 실행 시
   useEffect(() => {
     async function init() {
       //AsyncStorage.removeItem('userData');
       const value = JSON.parse(await AsyncStorage.getItem('userData'));
+      const planners = await getData(PLANNER_KEY);
+      console.log('🚀 ~ file: Gate.js ~ line 21 ~ init ~ planners', planners);
+      dispatch(addPlanners(planners));
       if (value.hasOwnProperty('password')) {
         // 아이디와 비밀번호로 회원가입한 적이 있으므로 다시 서버에 로그인 요청해서 JWT 재발급 후
         setIsLoggedIn(true);

--- a/src/screens/Main/Plan/PlanContainer.js
+++ b/src/screens/Main/Plan/PlanContainer.js
@@ -10,6 +10,7 @@ export default ({navigation, route}) => {
   });
 
   useEffect(() => {
+    console.log('🚀 ~ file: PlanContainer.js ~ line 11 ~ state', state);
     setState(prev => ({
       ...prev,
       planner: planners.find(planner => planner.id === id),

--- a/src/screens/Main/Plan/PlanContainer.js
+++ b/src/screens/Main/Plan/PlanContainer.js
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import PlanPresenter from './PlanPresenter';
+import {PLANNER_KEY, storeData} from '../../../api/storage';
 
 export default ({navigation, route}) => {
   const planners = useSelector(state => state.planners.planners);
@@ -10,7 +11,7 @@ export default ({navigation, route}) => {
   });
 
   useEffect(() => {
-    console.log('🚀 ~ file: PlanContainer.js ~ line 11 ~ state', state);
+    storeData(PLANNER_KEY, planners);
     setState(prev => ({
       ...prev,
       planner: planners.find(planner => planner.id === id),

--- a/src/screens/Main/Plan/PlanPresenter.js
+++ b/src/screens/Main/Plan/PlanPresenter.js
@@ -154,14 +154,14 @@ export default ({state, setState}) => {
             </PlanEditBtn>
           </PlanTitleContainer>
         )}
-        <Divider></Divider>
+        <Divider />
         <PlanItemsContainer category={'레크'} items={state?.planner.items} />
-        <Divider></Divider>
+        <Divider />
         <PlanItemsContainer category={'음식'} items={state?.planner.items} />
         <TotalPriceContainer>
           <TotalPrice state={state?.planner} />
         </TotalPriceContainer>
-        <Divider></Divider>
+        <Divider />
         <CautionContainer>
           <Caution caution={'주의사항'} />
         </CautionContainer>

--- a/src/screens/Main/Plan/PlanPresenter.js
+++ b/src/screens/Main/Plan/PlanPresenter.js
@@ -131,6 +131,8 @@ export default ({state, setState}) => {
     setTitle(e);
   };
 
+  useEffect(() => {}, [title]);
+
   return (
     <Container>
       <FocusAwareStatusBar barStyle="dark-content" backgroundColor="#ffffff" />

--- a/src/store/actions/planners.js
+++ b/src/store/actions/planners.js
@@ -1,4 +1,6 @@
 export const CREATE_PLANNER = 'CREATE_PLANNER';
+export const ADD_PLANNER = 'ADD_PLANNER';
+export const ADD_PLANNERS = 'ADD_PLANNERS';
 export const ADD_ITEM = 'ADD_ITEM';
 export const ADD_ITEMS = 'ADD_ITEMS';
 export const DELETE_PLANNER = 'DELETE_PLANNER';
@@ -7,6 +9,14 @@ export const UPDATE_PLANNER = 'UPDATE_PLANNER';
 
 export const createPlanner = title => {
   return {type: CREATE_PLANNER, title};
+};
+
+export const addPlanner = planner => {
+  return {type: ADD_PLANNER, planner};
+};
+
+export const addPlanners = planners => {
+  return {type: ADD_PLANNERS, planners};
 };
 
 export const addItem = (id, item, category) => {
@@ -20,6 +30,7 @@ export const addItems = (id, items, memberCnt, category) => {
 export const deletePlanner = id => {
   return {type: DELETE_PLANNER, id};
 };
+
 export const modifyPlannerTitle = (planner, title) => {
   return {type: MODIFY_TITLE, planner, title};
 };

--- a/src/store/reducers/planners.js
+++ b/src/store/reducers/planners.js
@@ -20,6 +20,22 @@ export default (state = initialState, action) => {
         planners: [...state.planners, newPlanner],
       };
     }
+    case 'ADD_PLANNER': {
+      const planner = action.planner;
+
+      return {
+        ...state,
+        planners: [...state.planners, planner],
+      };
+    }
+    case 'ADD_PLANNERS': {
+      const planners = action.planners;
+
+      return {
+        ...state,
+        planners: [...state.planners, ...planners],
+      };
+    }
     case 'ADD_ITEM': {
       const id = action.id;
       const category = action.category;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,6 +1505,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     "fastq" "^1.6.0"
 
+"@react-native-async-storage/async-storage@^1.15.17":
+  "integrity" "sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw=="
+  "resolved" "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz"
+  "version" "1.15.17"
+  dependencies:
+    "merge-options" "^3.0.4"
+
 "@react-native-community/cameraroll@>= 1.5.2":
   "integrity" "sha512-jkdhMByMKD2CZ/5MPeBieYn8vkCfC4MOTouPpBpps3I8N6HUYJk+1JnDdktVYl2WINnqXpQptDA2YptVyifYAg=="
   "resolved" "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.1.2.tgz"
@@ -5298,6 +5305,11 @@
   "resolved" "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   "version" "7.0.0"
 
+"is-plain-obj@^2.1.0":
+  "integrity" "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+  "resolved" "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
+  "version" "2.1.0"
+
 "is-plain-object@^2.0.3", "is-plain-object@^2.0.4":
   "integrity" "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="
   "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
@@ -6506,6 +6518,13 @@
     "map-age-cleaner" "^0.1.1"
     "mimic-fn" "^2.0.0"
     "p-is-promise" "^2.0.0"
+
+"merge-options@^3.0.4":
+  "integrity" "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ=="
+  "resolved" "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz"
+  "version" "3.0.4"
+  dependencies:
+    "is-plain-obj" "^2.1.0"
 
 "merge-stream@^2.0.0":
   "integrity" "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
@@ -8007,7 +8026,7 @@
     "whatwg-fetch" "^3.0.0"
     "ws" "^6.1.4"
 
-"react-native@*", "react-native@^0.67.0", "react-native@>=0.42.0", "react-native@>=0.50.0", "react-native@>=0.55", "react-native@>=0.57", "react-native@>=0.59", "react-native@>=0.59.0", "react-native@>=0.60", "react-native@>=0.62", "react-native@>=0.65.0", "react-native@>=0.65.0-rc.0 || 0.0.0-*", "react-native@>0.50.0", "react-native@0.65.1", "react-native@0.67.1":
+"react-native@*", "react-native@^0.0.0-0 || 0.60 - 0.67 || 1000.0.0", "react-native@^0.67.0", "react-native@>=0.42.0", "react-native@>=0.50.0", "react-native@>=0.55", "react-native@>=0.57", "react-native@>=0.59", "react-native@>=0.59.0", "react-native@>=0.60", "react-native@>=0.62", "react-native@>=0.65.0", "react-native@>=0.65.0-rc.0 || 0.0.0-*", "react-native@>0.50.0", "react-native@0.65.1", "react-native@0.67.1":
   "integrity" "sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ=="
   "resolved" "https://registry.npmjs.org/react-native/-/react-native-0.65.1.tgz"
   "version" "0.65.1"


### PR DESCRIPTION
## 개요
- 기획서를 async-storage로 저장하고 Gate.js에서 불러오도록 추가했습니다.

## 작업사항
- planner reducer에 addPlanners 추가
- storage.js에 Async-Storage 사용하는 코드 추가

## 변경로직
- 기존 `import {AsyncStorage} from 'react-navite'`는 deprecated 되었기 때문에 @react-native-async-storage/async-storage로 교체했습니다.

````javascript
import AsyncStorage from '@react-native-async-storage/async-storage';

export const PLANNER_KEY = '@planners';

export const storeData = async (key, value) => {
  try {
    const jsonValue = JSON.stringify(value);
    await AsyncStorage.setItem(key, jsonValue);
  } catch (e) {
    // saving error
  }
};

export const getData = async key => {
  try {
    const jsonValue = await AsyncStorage.getItem(key);
    return jsonValue != null ? JSON.parse(jsonValue) : null;
  } catch (e) {
    // error reading value
  }
};

````